### PR TITLE
Adds note about revocation in browsers

### DIFF
--- a/revoked-isrgrootx1.letsencrypt.org/index.html
+++ b/revoked-isrgrootx1.letsencrypt.org/index.html
@@ -177,7 +177,7 @@ h2.through-line::after {
 <!-- HTTP Content -->
 <div class="content">
   <div>
-    <p><b>NOTE:</b> Depending on your browser this page may not display as revoked. Not all browsers [perform revocation checking](https://www.imperialviolet.org/2014/04/19/revchecking.html).</p>
+    <p><b>NOTE:</b> Depending on your browser this page may not display as revoked. Not all browsers perform revocation checking.</p>
     <p><a href="https://letsencrypt.org/">Let's Encrypt</a> is a certificate authority. We created this page to demonstrate a revoked certificate that chains to our root certificate.</p>
     <div id="http">
       <h2 class="through-line">Get involved</h2>

--- a/revoked-isrgrootx1.letsencrypt.org/index.html
+++ b/revoked-isrgrootx1.letsencrypt.org/index.html
@@ -177,6 +177,7 @@ h2.through-line::after {
 <!-- HTTP Content -->
 <div class="content">
   <div>
+    <p><b>NOTE:</b> Depending on your browser this page may not display as revoked. Not all browsers [perform revocation checking](https://www.imperialviolet.org/2014/04/19/revchecking.html).</p>
     <p><a href="https://letsencrypt.org/">Let's Encrypt</a> is a certificate authority. We created this page to demonstrate a revoked certificate that chains to our root certificate.</p>
     <div id="http">
       <h2 class="through-line">Get involved</h2>


### PR DESCRIPTION
This PR adds a quick note as a follow-up to [a community forum thread](https://community.letsencrypt.org/t/isrg-root-test-pages-do-not-use-ocsp-stapling/24543) to indicate that the revoked test page will likely not appear revoked in most browsers due to the way they handle revocation checking.