### PR TITLE
Remove note about certificate expiration

### DIFF
--- a/expired-isrgrootx1.letsencrypt.org/index.html
+++ b/expired-isrgrootx1.letsencrypt.org/index.html
@@ -177,7 +177,6 @@ h2.through-line::after {
 <!-- HTTP Content -->
 <div class="content">
   <div>
-    <p><b>NOTE:</b> We know that this certificate has not yet expired. On 14 Feb 2017 the certificate will be expired and this site will properly demonstrate an expired certificate.</p>
     <p><a href="https://letsencrypt.org/">Let's Encrypt</a> is a certificate authority. We created this page to demonstrate an expired certificate that chains to our root certificate.</p>
     <div id="http">
       <h2 class="through-line">Get involved</h2>


### PR DESCRIPTION
We have passed through February and let the cert expire. We no longer need this note